### PR TITLE
IISCRUM-3365 Fixed typescript data type of getMaintenances second argument

### DIFF
--- a/src/datasource-zabbix/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
+++ b/src/datasource-zabbix/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
@@ -762,7 +762,7 @@ export class ZabbixAPIConnector {
     return this.request('valuemap.get', params);
   }
 
-  getMaintenances(hostids: string[], groupids?: string[]) {
+  getMaintenances(hostids: string[], groupids?: number[]) {
     const params = {
       hostids: hostids,
       output: ['active_since', 'active_till', 'name', 'maintenanceid'],

--- a/src/datasource-zabbix/zabbix/zabbix.ts
+++ b/src/datasource-zabbix/zabbix/zabbix.ts
@@ -245,7 +245,7 @@ export class Zabbix implements ZabbixConnector {
     .then(hosts => findByFilter(hosts, hostFilter));
   }
 
-  getMaintenances(hostids: string[], groupids?: string[]) {
+  getMaintenances(hostids: string[], groupids?: number[]) {
     return this.zabbixAPI.getMaintenances(hostids, groupids);
   }
 


### PR DESCRIPTION
Small TypeScript change that does not actually matter anything (just so that it's sync with the usage from grafana repo)