### PR TITLE
[HOTFIX] IISCRUM-3228 Active incidents, hide test tags.

### DIFF
--- a/src/panel-triggers/components/AlertList/AlertList.tsx
+++ b/src/panel-triggers/components/AlertList/AlertList.tsx
@@ -112,7 +112,7 @@ export default class AlertList extends PureComponent<AlertListProps, AlertListSt
         (priorityFilter === -1 || problem.severity === priorityFilter.toString()) &&
         (categoryFilter === 'all' || problem.opdata === categoryFilter) &&
         (!maintenanceFilter || problem.hosts.length === 0 || !problem.hosts.some((h) => h.maintenance_status === '1')) &&
-        (!testTagFilter || problem.tags.length === 0 || !problem.tags.some((e) => e.tag === 'test'))
+        (!testTagFilter || !problem.tags || !problem.tags.some((e) => e.tag === 'test'))
       );
     });
     if (sortOption === SORT_BY_PRIORITY) {


### PR DESCRIPTION
The checking for test tags was insufficient because if there are no tags, the tags object is not empty, it's "null". Also the checking was the other way around.